### PR TITLE
Revert "chore(deps): update helm release grafana to v6.21.4"

### DIFF
--- a/cluster/apps/monitoring/grafana/helm-release.yaml
+++ b/cluster/apps/monitoring/grafana/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: grafana
-      version: 6.21.4
+      version: 6.21.2
       sourceRef:
         kind: HelmRepository
         name: grafana-charts


### PR DESCRIPTION
Reverts bsherman/k3s-cluster#101

Seeing a problem:

```
Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:  6.21.2          False
                                                                  line 20: mapping key "port" already defined at line 16 
```